### PR TITLE
Pin rpm-ostree RPM version to protect against annoying updates

### DIFF
--- a/build-rpmostree.sh
+++ b/build-rpmostree.sh
@@ -11,7 +11,7 @@ set -e
 # Set up RPM build environment
 dnf install -y rpmdevtools rpm-build
 rpmdev-setuptree
-dnf download --source rpm-ostree
+dnf download --source rpm-ostree-2024.3-4.el9_4
 rpm -U ./rpm-ostree-*.src.rpm
 
 # apply necessary patches


### PR DESCRIPTION
When Oracle Linux updates rpm-ostree, it is often the case that the patch used by this tool before building rpm-ostree will break.  By pinning the specific version, this tool is protected against those changes.