### PR TITLE
Add -DI option to automatically generate container images for boot media

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,12 @@ ock-forge
   installation target is actually a file rather than a raw device.  This file
   is attached to the device specified with -d.
 
+ -DI | --disk-image *container-image*
+
+  A fully qualified container image name, including the tag.  Saves the disk
+  image in this image as is expected by various `ocne` commands that manipulate
+  boot media.
+
  -f | --filesystem *filesystem*
 
   The filesystem to use when formatting the root partition.  Only xfs is
@@ -238,6 +244,15 @@ Install using an existing ostree container image as a source.
 
 ```
 # ock-forge -d /dev/nbd0 -d /dev/loop0 -D out/1.30/boot.iso -i container-registry.oracle.com/olcne/ock-ostree:1.30 -P
+```
+
+#### Generate a Container Image with Boot Media
+
+Do a typical build for a `qcow2` image, and also generate a container image
+with that image.
+
+```
+# ock-forge -d /dev/nbd0 -D out/1.30/boot.qcow2 -i container-registry.oracle.com/olcne/ock-ostree:1.30 -O ./out/1.30/archive.tar -C ./ock -c configs/config-1.30 -P -DI container-registry.oracle.com/olcne/ock:1.30
 ```
 
 ## Other Utilities

--- a/build-image/install-bootloader.sh
+++ b/build-image/install-bootloader.sh
@@ -1,6 +1,6 @@
 #! /bin/bash
 #
-# Copyright (c) 2024, Oracle and/or its affiliates.
+# Copyright (c) 2024, 2026, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 set -e
 set -x

--- a/build-image/install-bootloader.sh
+++ b/build-image/install-bootloader.sh
@@ -72,6 +72,8 @@ SYSROOT="${DEPLOY}/sysroot"
 # - tmpfs
 # - bootloader config
 
+mkdir -p "$DEPLOY/etc"
+chmod 755 "$DEPLOY/etc"
 cat > "$DEPLOY/etc/fstab" << EOF
 UUID=$ROOT_FILESYSTEM_UUID / $FILESYSTEM defaults 0 0
 UUID=$BOOT_FILESYSTEM_UUID /boot xfs defaults,sync 0 0

--- a/ock-forge
+++ b/ock-forge
@@ -8,6 +8,7 @@ SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 
 DEVICE=
 DISK=
+DISK_IMAGE=
 FILESYSTEM=xfs
 IMAGE=
 CONFIG_DIR=
@@ -40,6 +41,12 @@ ock-forge [options] -d *device* (-i *ostree-image* | -C *directory* -c *director
   The path to a disk image file.  This values is only necessary if the
   installation target is actually a file rather than a raw device.  This file
   is attached to the device specified with -d.
+
+ -DI | --disk-image *container-image*
+
+  A fully qualified container image name, including the tag.  Saves the disk
+  image in this image as is expected by various `ocne` commands that manipulate
+  boot media.
 
  -f | --filesystem *filesystem*
 
@@ -139,6 +146,7 @@ while true; do
 	"") break;;
 	-d | --device ) DEVICE="$2"; shift; shift ;;
 	-D | --disk ) DISK="$2"; shift; shift ;;
+	-DI | --disk-image ) DISK_IMAGE="$2"; shift; shift ;;
 	-f | --filesystem ) FILESYSTEM="$2"; shift; shift ;;
 	-s | --source ) SOURCE="$2"; shift; shift; ;;
 	-b | --branch ) BRANCH="$2"; shift; shift ;;
@@ -318,5 +326,18 @@ if [[ -n "$CLEAN" ]]; then
 		losetup -d "$DEVICE"
 	fi
 fi
+
+# If a container image with the boot media is desired, package it up.
+if [[ -n "$DISK_IMAGE" ]]; then
+	DI_FILE=$(basename "$DISK")
+	DI_DIR=$(dirname "$DISK")
+	DOCKERFILE=$(cat << EOF
+FROM scratch
+COPY $DI_FILE /disk/boot.qcow2
+EOF
+)
+	podman build -t "$DISK_IMAGE" -f <(echo "$DOCKERFILE") "$DI_DIR"
+fi
+
 
 popd

--- a/ock-forge
+++ b/ock-forge
@@ -1,6 +1,6 @@
 #! /bin/bash
 #
-# Copyright (c) 2024, Oracle and/or its affiliates.
+# Copyright (c) 2024, 2026, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 set -e
 


### PR DESCRIPTION
Create container images out of the boot media that `ock-forge` generates.

```
# ./ock-forge -d /dev/nbd0 -D out/1.33/boot.qcow2 -i container-registry.oracle.com/olcne/ock-ostree:1.33 -O ./out/1.33/archive.tar -C ./ock -c configs/config-1.33 -P -DI localhost/ock-image-test:1.33
+ [[ -z '' ]]
+ [[ -z '' ]]
+ IGNITION_PROVIDER=qemu
+ [[ -n out/1.33/boot.qcow2 ]]
++ realpath -m out/1.33/boot.qcow2
+ DISK=/root/git/ock-forge/out/1.33/boot.qcow2
+ [[ -n ./ock ]]

...

+ ./sparsify-image.sh -D /root/git/ock-forge/out/1.33/boot.qcow2
+ set -e
+ DISK=
+ true
+ case "$1" in
+ DISK=/root/git/ock-forge/out/1.33/boot.qcow2
+ shift
+ shift
+ true
+ case "$1" in
+ break
+ [[ -z /root/git/ock-forge/out/1.33/boot.qcow2 ]]
+ TMP_DISK=/root/git/ock-forge/out/1.33/boot.qcow2-tmp
+ qemu-img convert -c -f qcow2 -O qcow2 /root/git/ock-forge/out/1.33/boot.qcow2 /root/git/ock-forge/out/1.33/boot.qcow2-tmp
+ rm /root/git/ock-forge/out/1.33/boot.qcow2
+ cp --sparse=always /root/git/ock-forge/out/1.33/boot.qcow2-tmp /root/git/ock-forge/out/1.33/boot.qcow2
+ rm /root/git/ock-forge/out/1.33/boot.qcow2-tmp
+ [[ -n localhost/ock-image-test:1.33 ]]
++ basename /root/git/ock-forge/out/1.33/boot.qcow2
+ DI_FILE=boot.qcow2
++ dirname /root/git/ock-forge/out/1.33/boot.qcow2
+ DI_DIR=/root/git/ock-forge/out/1.33
++ cat
+ DOCKERFILE='FROM scratch
COPY boot.qcow2 /disk/boot.qcow2'
+ podman build -t localhost/ock-image-test:1.33 -f /dev/fd/63 /root/git/ock-forge/out/1.33
++ echo 'FROM scratch
COPY boot.qcow2 /disk/boot.qcow2'
STEP 1/2: FROM scratch
STEP 2/2: COPY boot.qcow2 /disk/boot.qcow2
COMMIT localhost/ock-image-test:1.33
--> bdd1e089c444
Successfully tagged localhost/ock-image-test:1.33
bdd1e089c444f7956bb2317adcf5d7c5bc201941fff0c2480fb6bd7b16919592
+ popd
~/git/ock-forge
```

```
# podman images | grep ock-image-test
localhost/ock-image-test                                                      1.33        bdd1e089c444  About an hour ago  2.56 GB

# podman image mount localhost/ock-image-test:1.33
/var/lib/containers/storage/overlay/bd784c6bcbcf61f2ccdc63616a0ee4e2f38009c97e2a7989134167a15f5248b0/merged
[root@ol9 ock-forge]# ls /var/lib/containers/storage/overlay/bd784c6bcbcf61f2ccdc63616a0ee4e2f38009c97e2a7989134167a15f5248b0/merged

# ls /var/lib/containers/storage/overlay/bd784c6bcbcf61f2ccdc63616a0ee4e2f38009c97e2a7989134167a15f5248b0/merged/disk
boot.qcow2
```